### PR TITLE
Fix numbering

### DIFF
--- a/docs/source/opengl.rst
+++ b/docs/source/opengl.rst
@@ -34,7 +34,7 @@ array of matrices:
    /* ... */
    glUniformMatrix4fv(location, count, GL_FALSE, matrix[0][0]);
 
-1. Cast matrix to pointer
+2. Cast matrix to pointer
 --------------------------
 
 .. code-block:: c


### PR DESCRIPTION
I think this was supposed to be 2, as the first example was `1. Pass the first column` (docs/source/opengl.rst:17)

